### PR TITLE
feat: 디스코드 메시지에서 소수점 제거

### DIFF
--- a/app/adapters/external/discord/adapter.py
+++ b/app/adapters/external/discord/adapter.py
@@ -164,11 +164,11 @@ class DiscordAdapter:
         )
 
         embed.add_field(name="체결 가격", value=f"{price:,.0f} KRW", inline=True)
-        embed.add_field(name="체결 수량", value=f"{volume:.8f}", inline=True)
+        embed.add_field(name="체결 수량", value=f"{int(volume)}", inline=True)
         embed.add_field(
             name="총 거래 금액", value=f"{total_price:,.0f} KRW", inline=True
         )
-        embed.add_field(name="수수료", value=f"{fee:,.2f} KRW", inline=True)
+        embed.add_field(name="수수료", value=f"{int(fee)} KRW", inline=True)
         embed.add_field(name="거래 유형", value=action, inline=True)
         embed.add_field(
             name="체결 시간",

--- a/app/adapters/internal/websocket/discord_bot.py
+++ b/app/adapters/internal/websocket/discord_bot.py
@@ -49,7 +49,7 @@ def _create_trade_confirmation_embed(
 
     embed.add_field(
         name=f"{DiscordConstants.EMOJI_WARNING} 주의사항",
-        value=f"{DiscordConstants.EMOJI_CONFIRM} 또는 {DiscordConstants.EMOJI_CANCEL} 이모지로 응답해주세요.\n{DiscordConstants.TRADE_CONFIRMATION_TIMEOUT_SECONDS:.0f}초 내에 응답하지 않으면 취소됩니다.",
+        value=f"{DiscordConstants.EMOJI_CONFIRM} 또는 {DiscordConstants.EMOJI_CANCEL} 이모지로 응답해주세요.\n{int(DiscordConstants.TRADE_CONFIRMATION_TIMEOUT_SECONDS)}초 내에 응답하지 않으면 취소됩니다.",
         inline=False,
     )
 
@@ -467,7 +467,7 @@ def _create_order_commands(order_usecase: OrderUseCase) -> list[Any]:
             )
             embed.add_field(
                 name=f"{DiscordConstants.EMOJI_WARNING} 주의사항",
-                value=f"{DiscordConstants.EMOJI_CONFIRM} 또는 {DiscordConstants.EMOJI_CANCEL} 이모지로 응답해주세요.\n{DiscordConstants.TRADE_CONFIRMATION_TIMEOUT_SECONDS:.0f}초 내에 응답하지 않으면 취소됩니다.",
+                value=f"{DiscordConstants.EMOJI_CONFIRM} 또는 {DiscordConstants.EMOJI_CANCEL} 이모지로 응답해주세요.\n{int(DiscordConstants.TRADE_CONFIRMATION_TIMEOUT_SECONDS)}초 내에 응답하지 않으면 취소됩니다.",
                 inline=False,
             )
 
@@ -546,13 +546,13 @@ def _create_balance_command(account_usecase: AccountUseCase) -> Any:
                     if balance_val > 0 or locked_val > 0:
                         total = balance_val + locked_val
                         message += f"\n**{balance.currency}**\n"
-                        message += f"  • 사용 가능: {balance_val:,.8f}\n"
-                        message += f"  • 거래 중: {locked_val:,.8f}\n"
-                        message += f"  • 총 보유: {total:,.8f}\n"
+                        message += f"  • 사용 가능: {int(balance_val)}\n"
+                        message += f"  • 거래 중: {int(locked_val)}\n"
+                        message += f"  • 총 보유: {int(total)}\n"
 
                         avg_buy_price = float(balance.avg_buy_price)
                         if avg_buy_price > 0:
-                            message += f"  • 평균 매수가: {avg_buy_price:,.2f} KRW\n"
+                            message += f"  • 평균 매수가: {int(avg_buy_price)} KRW\n"
 
                 message += (
                     f"\n💵 **총 평가 금액**: {float(result.total_balance_krw):,.0f} KRW"
@@ -590,10 +590,10 @@ def _create_price_command(ticker_usecase: TickerUseCase) -> Any:
 
                 message = f"{change_emoji} **{market} 시세 정보**\n\n"
                 message += f"**현재가**: {float(ticker.trade_price):,.0f} KRW\n"
-                message += f"**전일 대비**: {change_color} {float(ticker.signed_change_price):+,.0f} ({change_rate:+.2f}%)\n"
+                message += f"**전일 대비**: {change_color} {float(ticker.signed_change_price):+,.0f} ({int(change_rate):+}%)\n"
                 message += f"**고가**: {float(ticker.high_price):,.0f} KRW\n"
                 message += f"**저가**: {float(ticker.low_price):,.0f} KRW\n"
-                message += f"**거래량**: {float(ticker.acc_trade_volume_24h):,.4f}\n"
+                message += f"**거래량**: {int(float(ticker.acc_trade_volume_24h))}\n"
                 message += f"**거래대금**: {float(ticker.acc_trade_price_24h):,.0f} KRW"
 
                 await ctx.send(message)


### PR DESCRIPTION
## 변경사항 요약

이 PR은 디스코드 메시지에서 모든 소수점을 제거하여 더 깔끔한 정수 표시로 변경합니다.

## 상세 변경 내용

### 거래 체결 알림 (Discord Adapter)
- **체결 수량**: `{volume:.8f}` → `{int(volume)}`
- **수수료**: `{fee:,.2f} KRW` → `{int(fee)} KRW`

### 잔고 조회 명령어 (Discord Bot)
- **사용 가능 잔고**: `{balance_val:,.8f}` → `{int(balance_val)}`
- **거래 중 잔고**: `{locked_val:,.8f}` → `{int(locked_val)}`
- **총 보유량**: `{total:,.8f}` → `{int(total)}`
- **평균 매수가**: `{avg_buy_price:,.2f} KRW` → `{int(avg_buy_price)} KRW`

### 시세 조회 명령어 (Discord Bot)
- **전일 대비 변동률**: `{change_rate:+.2f}%` → `{int(change_rate):+}%`
- **24시간 거래량**: `{float(ticker.acc_trade_volume_24h):,.4f}` → `{int(float(ticker.acc_trade_volume_24h))}`

### 거래 확인 메시지
- **타임아웃 표시**: `{DiscordConstants.TRADE_CONFIRMATION_TIMEOUT_SECONDS:.0f}초` → `{int(DiscordConstants.TRADE_CONFIRMATION_TIMEOUT_SECONDS)}초`

## 테스트 완료 사항
- [x] 파이썬 문법 검사 통과
- [x] pre-commit 훅 검사 통과 (ruff, mypy 등)

## 주의사항
- 암호화폐 수량이 1 미만인 경우 0으로 표시됨 (예: 0.0001 BTC → 0)
- 수수료가 1원 미만인 경우 0으로 표시됨
- 변동률의 소수점 정보가 손실됨 (예: 1.5% → 1%)

이러한 변경사항은 사용자 요청에 따른 의도적인 단순화입니다. 